### PR TITLE
First pass at ax^2 + bx = c circuit in halo2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "quadratic"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "halo2_hello_world"
+path = "src/lib.rs"
+
+[dependencies]
+halo2_proofs = "0.2.0"

--- a/src/add.rs
+++ b/src/add.rs
@@ -1,0 +1,1 @@
+pub mod lib;

--- a/src/add/lib.rs
+++ b/src/add/lib.rs
@@ -1,0 +1,120 @@
+/// Constructs the Add chip.
+use std::marker::PhantomData;
+
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::{Chip, Layouter, Region},
+    plonk::{Advice, Column, ConstraintSystem, Error, Selector},
+    poly::Rotation,
+};
+
+/// Interface for the AddInstruction.
+pub(crate) trait AddInstructions<F: FieldExt>: Chip<F> {
+    /// Variable representing a number.
+    type Num;
+
+    /// Returns `c = a + b`.
+    fn add(
+        &self,
+        layouter: impl Layouter<F>,
+        a: Self::Num,
+        b: Self::Num,
+    ) -> Result<Self::Num, Error>;
+}
+
+/// Config for the add chip.
+#[derive(Clone, Debug)]
+pub(crate) struct AddConfig {
+    /// One advice column for the instruction.
+    advice: Column<Advice>,
+    /// Selector for the add instruction.
+    s_add: Selector,
+}
+
+/// A chip for the add functionality.
+pub(crate) struct AddChip<F: FieldExt> {
+    config: AddConfig,
+    _marker: PhantomData<F>,
+}
+
+// Implementations for the add chip below.
+
+impl<F: FieldExt> Chip<F> for AddChip<F> {
+    type Config = AddConfig;
+    type Loaded = ();
+
+    fn config(&self) -> &Self::Config {
+        &self.config
+    }
+
+    fn loaded(&self) -> &Self::Loaded {
+        &()
+    }
+}
+
+impl<F: FieldExt> AddChip<F> {
+    pub(crate) fn construct(config: <Self as Chip<F>>::Config) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn configure(
+        meta: &mut ConstraintSystem<F>,
+        advice: Column<Advice>,
+    ) -> <Self as Chip<F>>::Config {
+        meta.enable_equality(advice);
+        let s_add = meta.selector();
+
+        // Define our addition gate.
+        meta.create_gate("add", |meta| {
+            // We want three advice cells and a selector cell.
+            // | a0  | s_add |
+            // |-----|-------|
+            // | lhs | s_add |
+            // | rhs |       |
+            // | out |       |
+            let lhs = meta.query_advice(advice, Rotation::cur());
+            let rhs = meta.query_advice(advice, Rotation::next());
+            // ::next() is not an iterator.
+            let out = meta.query_advice(advice, Rotation(2));
+            let s_add = meta.query_selector(s_add);
+
+            // When s_add = 0, any value is allowed in lhs, rhs, out.
+            // When s_add != 0, lhs + rhs = out.
+            vec![s_add * (lhs + rhs - out)]
+        });
+
+        AddConfig { advice, s_add }
+    }
+}
+
+impl<F: FieldExt> AddInstructions<F> for AddChip<F> {
+    type Num = crate::Number<F>;
+
+    fn add(
+        &self,
+        mut layouter: impl Layouter<F>,
+        a: Self::Num,
+        b: Self::Num,
+    ) -> Result<Self::Num, Error> {
+        let config = self.config();
+
+        layouter.assign_region(
+            || "add",
+            |mut region: Region<'_, F>| {
+                config.s_add.enable(&mut region, 0)?;
+
+                a.0.copy_advice(|| "lhs", &mut region, config.advice, 0)?;
+                b.0.copy_advice(|| "rhs", &mut region, config.advice, 1)?;
+
+                let value = a.0.value().copied() + b.0.value().copied();
+
+                region
+                    .assign_advice(|| "lhs + rhs", config.advice, 2, || value)
+                    .map(crate::Number)
+            },
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,297 @@
+use std::marker::PhantomData;
+
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::{AssignedCell, Chip, Layouter, SimpleFloorPlanner, Value},
+    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Instance},
+};
+
+mod add;
+mod mul;
+
+use add::lib::{AddChip, AddConfig, AddInstructions};
+use mul::lib::{MulChip, MulConfig, MulInstructions};
+
+/// A variable representing a number. (Why?)
+#[derive(Clone)]
+struct Number<F: FieldExt>(AssignedCell<F, F>);
+
+trait SolutionInstructions<F: FieldExt>: AddInstructions<F> + MulInstructions<F> {
+    /// Variable representing a number.
+    type Num;
+
+    /// Loads a number into the circuit as a private input.
+    fn load_private(
+        &self,
+        layouter: impl Layouter<F>,
+        a: Value<F>,
+    ) -> Result<<Self as SolutionInstructions<F>>::Num, Error>;
+
+    /// Loads a, b, c into the circuit.
+    fn load_constants(
+        &self,
+        layouter: impl Layouter<F>,
+    ) -> Result<[<Self as SolutionInstructions<F>>::Num; 3], Error>;
+
+    /// Exposes a number as a public input to the circuit.
+    fn expose_public(
+        &self,
+        layouter: impl Layouter<F>,
+        num: <Self as SolutionInstructions<F>>::Num,
+        row: usize,
+    ) -> Result<(), Error>;
+
+    /// Returns a * x^2 + b * x - c.
+    fn solve_quadratic(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        a: <Self as SolutionInstructions<F>>::Num,
+        b: <Self as SolutionInstructions<F>>::Num,
+        c: <Self as SolutionInstructions<F>>::Num,
+        x: <Self as SolutionInstructions<F>>::Num,
+    ) -> Result<<Self as SolutionInstructions<F>>::Num, Error>;
+}
+
+struct SolutionChip<F: FieldExt> {
+    config: SolutionConfig,
+    _marker: PhantomData<F>,
+}
+
+#[derive(Clone, Debug)]
+struct SolutionConfig {
+    /// One column for the instruction.
+    advice: Column<Advice>,
+    // TODO: Should we be able to collapse this into one instance column?
+    /// The value a.
+    a: Column<Instance>,
+    /// The value b.
+    b: Column<Instance>,
+    /// The value c.
+    c: Column<Instance>,
+
+    add_config: AddConfig,
+    mul_config: MulConfig,
+}
+
+impl<F: FieldExt> Chip<F> for SolutionChip<F> {
+    type Config = SolutionConfig;
+    type Loaded = ();
+
+    fn config(&self) -> &Self::Config {
+        &self.config
+    }
+
+    fn loaded(&self) -> &Self::Loaded {
+        &()
+    }
+}
+
+impl<F: FieldExt> AddInstructions<F> for SolutionChip<F> {
+    type Num = Number<F>;
+
+    fn add(
+        &self,
+        layouter: impl Layouter<F>,
+        a: Self::Num,
+        b: Self::Num,
+    ) -> Result<Self::Num, Error> {
+        let config = self.config().add_config.clone();
+        let add_chip = AddChip::<F>::construct(config);
+        add_chip.add(layouter, a, b)
+    }
+}
+
+impl<F: FieldExt> MulInstructions<F> for SolutionChip<F> {
+    type Num = Number<F>;
+
+    fn mul(
+        &self,
+        layouter: impl Layouter<F>,
+        a: Self::Num,
+        b: Self::Num,
+    ) -> Result<Self::Num, Error> {
+        let config = self.config().mul_config.clone();
+        let mul_chip = MulChip::<F>::construct(config);
+        mul_chip.mul(layouter, a, b)
+    }
+}
+
+impl<F: FieldExt> SolutionChip<F> {
+    fn construct(config: <Self as Chip<F>>::Config) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        advice: Column<Advice>,
+        a: Column<Instance>,
+        b: Column<Instance>,
+        c: Column<Instance>,
+    ) -> <Self as Chip<F>>::Config {
+        let add_config = AddChip::configure(meta, advice);
+        let mul_config = MulChip::configure(meta, advice);
+        meta.enable_equality(a);
+        meta.enable_equality(b);
+        meta.enable_equality(c);
+
+        SolutionConfig {
+            add_config,
+            mul_config,
+            advice,
+            a,
+            b,
+            c,
+        }
+    }
+}
+
+impl<F: FieldExt> SolutionInstructions<F> for SolutionChip<F> {
+    type Num = crate::Number<F>;
+
+    fn load_private(
+        &self,
+        mut layouter: impl Layouter<F>,
+        value: Value<F>,
+    ) -> Result<<Self as SolutionInstructions<F>>::Num, Error> {
+        let config = self.config();
+
+        layouter.assign_region(
+            || "load private",
+            |mut region| {
+                region
+                    .assign_advice(|| "private input", config.advice, 0, || value)
+                    .map(Number)
+            },
+        )
+    }
+
+    fn load_constants(
+        &self,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<[<Self as SolutionInstructions<F>>::Num; 3], Error> {
+        let config = self.config();
+
+        layouter.assign_region(
+            || "load constants",
+            |mut region| {
+                let a = region
+                    .assign_advice_from_instance(|| "a", config.a, 0, config.advice, 0)
+                    .map(Number)?;
+                let b = region
+                    .assign_advice_from_instance(|| "b", config.b, 0, config.advice, 1)
+                    .map(Number)?;
+                let c = region
+                    .assign_advice_from_instance(|| "c", config.c, 0, config.advice, 2)
+                    .map(Number)?;
+
+                return Ok([a, b, c]);
+            },
+        )
+    }
+
+    fn expose_public(
+        &self,
+        mut layouter: impl Layouter<F>,
+        num: <Self as SolutionInstructions<F>>::Num,
+        row: usize,
+    ) -> Result<(), Error> {
+        let config = self.config();
+
+        layouter.constrain_instance(num.0.cell(), config.c, row)
+    }
+
+    fn solve_quadratic(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        a: <Self as SolutionInstructions<F>>::Num,
+        b: <Self as SolutionInstructions<F>>::Num,
+        _c: <Self as SolutionInstructions<F>>::Num,
+        x: <Self as SolutionInstructions<F>>::Num,
+    ) -> Result<<Self as SolutionInstructions<F>>::Num, Error> {
+        let x2 = self.mul(layouter.namespace(|| "x2"), x.clone(), x.clone())?;
+        let bx = self.mul(layouter.namespace(|| "bx"), b, x)?;
+        let ax2 = self.mul(layouter.namespace(|| "ax2"), a, x2)?;
+        self.add(layouter.namespace(|| "ax2 + bx"), ax2, bx)
+    }
+}
+
+// The full circuit.
+#[derive(Default)]
+struct MyCircuit<F: FieldExt> {
+    x: Value<F>,
+}
+
+impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
+    type Config = SolutionConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        let advice = meta.advice_column();
+
+        let a = meta.instance_column();
+        let b = meta.instance_column();
+        let c = meta.instance_column();
+
+        SolutionChip::configure(meta, advice, a, b, c)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let solution_chip = SolutionChip::<F>::construct(config);
+
+        let x = solution_chip.load_private(layouter.namespace(|| "load x"), self.x)?;
+        let [a, b, c] = solution_chip.load_constants(layouter.namespace(|| "load a,b,c"))?;
+
+        let solution = solution_chip.solve_quadratic(&mut layouter, a, b, c, x)?;
+
+        solution_chip.expose_public(layouter.namespace(|| "expose solution"), solution, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MyCircuit;
+    use halo2_proofs::{circuit::Value, dev::MockProver, pasta::Fp};
+
+    #[test]
+    fn test_solve_quad() {
+        let k = 5;
+        let a = Fp::from(1);
+        let b = Fp::from(2);
+        let c = Fp::from(3);
+        let x = Fp::from(1);
+
+        let circuit = MyCircuit {
+            x: Value::known(x),
+        };
+
+        let prover = MockProver::run(k, &circuit, vec![vec![a], vec![b], vec![c]]).unwrap();
+        assert_eq!(prover.verify(), Ok(()));
+    }
+
+    #[test]
+    fn test_fail_quad() {
+        let k = 5;
+        let a = Fp::from(1);
+        let b = Fp::from(1);
+        let c = Fp::from(3);
+        let x = Fp::from(1);
+
+        let circuit = MyCircuit {
+            x: Value::known(x),
+        };
+
+        let prover = MockProver::run(k, &circuit, vec![vec![a], vec![b], vec![c]]).unwrap();
+        assert!(prover.verify().is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod mul;
 use add::lib::{AddChip, AddConfig, AddInstructions};
 use mul::lib::{MulChip, MulConfig, MulInstructions};
 
-/// A variable representing a number. (Why?)
+/// A variable representing a number.
 #[derive(Clone)]
 struct Number<F: FieldExt>(AssignedCell<F, F>);
 
@@ -61,7 +61,7 @@ struct SolutionChip<F: FieldExt> {
 struct SolutionConfig {
     /// One column for the instruction.
     advice: Column<Advice>,
-    // TODO: Should we be able to collapse this into one instance column?
+    // TODO: Collapse this into one instance column?
     /// The value a.
     a: Column<Instance>,
     /// The value b.

--- a/src/mul.rs
+++ b/src/mul.rs
@@ -1,0 +1,1 @@
+pub mod lib;

--- a/src/mul/lib.rs
+++ b/src/mul/lib.rs
@@ -1,0 +1,113 @@
+/// Constructs the Mul chip.
+use std::marker::PhantomData;
+
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::{Chip, Layouter, Region},
+    plonk::{Advice, Column, ConstraintSystem, Error, Selector},
+    poly::Rotation,
+};
+
+pub(crate) trait MulInstructions<F: FieldExt>: Chip<F> {
+    /// Variable representing a number.
+    type Num;
+
+    /// Returns `c = a * b`.
+    fn mul(
+        &self,
+        layouter: impl Layouter<F>,
+        a: Self::Num,
+        b: Self::Num,
+    ) -> Result<Self::Num, Error>;
+}
+
+pub(crate) struct MulChip<F: FieldExt> {
+    config: MulConfig,
+    _marker: PhantomData<F>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MulConfig {
+    /// Two advice columns for the instruction.
+    advice: Column<Advice>,
+    /// Selector for the multiply instruction.
+    s_mul: Selector,
+}
+
+impl<F: FieldExt> Chip<F> for MulChip<F> {
+    type Config = MulConfig;
+    type Loaded = ();
+
+    fn config(&self) -> &Self::Config {
+        &self.config
+    }
+
+    fn loaded(&self) -> &Self::Loaded {
+        &()
+    }
+}
+
+impl<F: FieldExt> MulChip<F> {
+    pub(crate) fn construct(config: <Self as Chip<F>>::Config) -> Self {
+        Self {
+            config,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn configure(
+        meta: &mut ConstraintSystem<F>,
+        advice: Column<Advice>,
+    ) -> <Self as Chip<F>>::Config {
+        meta.enable_equality(advice);
+        let s_mul = meta.selector();
+
+        // Define our multiplication gate.
+        meta.create_gate("mul", |meta| {
+            // We want three advice cells and a selector cell.
+            // | a0  | s_mul |
+            // |-----|-------|
+            // | lhs | s_mul |
+            // | rhs |       |
+            // | out |       |
+            let lhs = meta.query_advice(advice, Rotation::cur());
+            let rhs = meta.query_advice(advice, Rotation::next());
+            let out = meta.query_advice(advice, Rotation(2));
+            let s_mul = meta.query_selector(s_mul);
+
+            // When s_add = 0, any value is allowed in lhs, rhs, out.
+            // When s_add != 0, lhs * rhs = out.
+            vec![s_mul * (lhs * rhs - out)]
+        });
+
+        MulConfig { advice, s_mul }
+    }
+}
+
+impl<F: FieldExt> MulInstructions<F> for MulChip<F> {
+    type Num = crate::Number<F>;
+
+    fn mul(
+        &self,
+        mut layouter: impl Layouter<F>,
+        a: Self::Num,
+        b: Self::Num,
+    ) -> Result<Self::Num, Error> {
+        let config = self.config();
+
+        layouter.assign_region(
+            || "mul",
+            |mut region: Region<'_, F>| {
+                config.s_mul.enable(&mut region, 0)?;
+                a.0.copy_advice(|| "lhs", &mut region, config.advice, 0)?;
+                b.0.copy_advice(|| "rhs", &mut region, config.advice, 1)?;
+
+                let value = a.0.value().copied() * b.0.value().copied();
+
+                region
+                    .assign_advice(|| "lhs * rhs", config.advice, 2, || value)
+                    .map(crate::Number)
+            },
+        )
+    }
+}


### PR DESCRIPTION
Initial circuit that takes x private, a,b,c known and proves ax^2 + bx = c.

Contains `Add` and `Mul` chips, and contains two rudimentary tests. Circuit compiles and passes test cases. Currently passes in a,b,c through 3 separate instance columns.